### PR TITLE
Custom indentation can be specified in the Gruntfile

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,14 @@ Type: `String`
 Specify a relative path to your RequireJS config
 
 
+### indent
+
+**Optional**  
+Type: `String`
+
+Specify an indentation string to use when updating the paths property. Default is 4 spaces
+
+
 ## License
 
 [BSD license](http://opensource.org/licenses/bsd-license.php) and copyright Google

--- a/tasks/bower-hooks.js
+++ b/tasks/bower-hooks.js
@@ -24,7 +24,7 @@ module.exports = function (grunt) {
 					rjsConfig = file.replace(reConfig, function (match, p1) {
 						var config =JSON5.parse(p1);
 						_.extend(config.paths, data);
-						return 'require.config(' + stringifyObject(config, {indent: '    '});
+						return 'require.config(' + stringifyObject(config, {indent: grunt.config('bower.indent') || '    '});
 					});
 
 					grunt.file.write(filePath, rjsConfig);


### PR DESCRIPTION
This patch adds the option to specify the indentation in your Gruntfile as per issue #3. Currently four spaces are used.

The indent value is optional and if unspecified the default of four space will be applied.

Indentation can be specified in your Gruntfile like so.

``` javascript
bower: {
  rjsConfig: 'scripts/config.js',
  // Use 2 spaces for indentation (default is 4)
  indent: '  '
}
```

I've also added the option to the readme file.
