### PR TITLE
Create paths based on filename if main contains more than one .js file

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,8 +56,14 @@ module.exports = function (grunt) {
 
 	grunt.registerTask('bower-install', function () {
 		require('bower').commands
-			.install(['jquery', 'underscore', 'requirejs'])
-			.on('end', this.async());
+			.install([
+				'jquery',
+				'underscore',
+				'requirejs',
+				'anima',
+				'typeahead.js',
+				'highstock'
+			]).on('end', this.async());
 	});
 
 	grunt.registerTask('test', [

--- a/test/fixtures/baseurl-config-expected.js
+++ b/test/fixtures/baseurl-config-expected.js
@@ -6,6 +6,11 @@ require.config({
   paths: {
     hm: 'vendor/hm',
     esprima: 'vendor/esprima',
-    jquery: '../../components/jquery/jquery'
+    anima: '../../components/anima/anima.min',
+    jquery: '../../components/jquery/jquery',
+    typeahead: '../../components/typeahead.js/dist/typeahead',
+    highcharts: '../../components/highstock/js/highcharts.src',
+    highstock: '../../components/highstock/js/highstock.src',
+    'highcharts-more': '../../components/highstock/js/highcharts-more.src'
   }
 });

--- a/test/fixtures/config-expected.js
+++ b/test/fixtures/config-expected.js
@@ -5,6 +5,11 @@ require.config({
   paths: {
     hm: 'vendor/hm',
     esprima: 'vendor/esprima',
-    jquery: 'components/jquery/jquery'
+    anima: 'components/anima/anima.min',
+    jquery: 'components/jquery/jquery',
+    typeahead: 'components/typeahead.js/dist/typeahead',
+    highcharts: 'components/highstock/js/highcharts.src',
+    highstock: 'components/highstock/js/highstock.src',
+    'highcharts-more': 'components/highstock/js/highcharts-more.src'
   }
 });

--- a/test/fixtures/global-config-expected.js
+++ b/test/fixtures/global-config-expected.js
@@ -5,6 +5,11 @@ var require = {
   paths: {
     hm: 'vendor/hm',
     esprima: 'vendor/esprima',
-    jquery: 'components/jquery/jquery'
+    anima: 'components/anima/anima.min',
+    jquery: 'components/jquery/jquery',
+    typeahead: 'components/typeahead.js/dist/typeahead',
+    highcharts: 'components/highstock/js/highcharts.src',
+    highstock: 'components/highstock/js/highstock.src',
+    'highcharts-more': 'components/highstock/js/highcharts-more.src'
   }
 };


### PR DESCRIPTION
- Updated tests so they work with the new array conditions
- Added highstock and typeahead.js to tests
- Paths that would end up as 'typehead.js': 'path/to/typehead' now truncate down to 'typehead': 'path/to/typehead'. The user is warned that this is happening in the console output.
- The user is warned if one of their dependencies does not specify a js file in `main`.
