### PR TITLE
Allow a directory to be specified as main

### DIFF
--- a/tasks/bower-requirejs.js
+++ b/tasks/bower-requirejs.js
@@ -91,7 +91,7 @@ module.exports = function (grunt) {
 								// iterate through the main array and filter it down
 								// to only .js files
 								var jsfiles = _.filter(val, function(inval) {
-									return path.extname(inval) === '.js';
+									return path.extname(inval) === '.js' || grunt.file.isDir(inval);
 								});
 
 								// if there are no js files in main, delete


### PR DESCRIPTION
Currently the main key in bower.json can be a file or list of javascript files. This change allows main to point to a directory, useful for requirejs libraries e.g. https://github.com/mout/mout.
