### PR TITLE
Programmatic api readme updates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,71 @@ The tool does not overwrite the config file, it just adds additional paths to it
 Although RequireJS does not provide a `bower.json` file, a path to `require.js` will still be created in your `rjsConfig` file. The path's name will be `requirejs`. If you are optimizing your scripts with `r.js` you can use this path to make sure RequireJS is included in your bundle.
 
 
+## Programmatic API
+
+### bowerRequireJS(args, options, callback)
+
+- `args` — Command-line arguments, typically used for the binary. If you're working with bower-requirejs directly in your app you can just pass in an empty object.
+- `options` — An [options object](https://github.com/yeoman/bower-requirejs#options) containing a config and optional baseUrl and excludes.
+- `callback` — A callback to execute when the task is finished
+
+You can use `bower-requirejs` directly in your app if you prefer to not rely on the binary.
+
+```js
+var bowerRequireJS = require('bower-requirejs');
+
+var options = {
+  config: 'scripts/config.js',
+  exclude: ['underscore', 'jquery']
+};
+
+bowerRequrieJS({}, options, function () {
+  // all done!
+});
+```
+
+
+### parse(pkg, name, baseUrl)
+
+- `pkg` — A package object returned from `bower list`
+- `name` — The name of the package
+- `baseUrl` — A baseUrl to use when generating the path
+
+If you would like to just receive a paths object you can do so with the `parse` module. If your package does not contain a `bower.json` file, or if the `bower.json` does not contain a `main` attribute then the parse module will try to use the `primary` module to find a primary, top-level js file.
+
+```js
+var bower = require('bower');
+var parse = require('bower-requirejs/lib/parse');
+
+var baseUrl = './';
+
+bower.commands.list()
+  .on('end', function (data) {
+    _.forOwn(data, function (pkg, name) {
+      if (name == 'jquery') {
+        var pathObj = parse(pkg, name, baseUrl);
+      }
+    });
+  })
+```
+
+### primary(name, canonicalDir)
+
+- `name` — The package name
+- `canonicalDir` — The canonicalDir for the package, either returned by `bower list` or passed in manually
+
+If you just want to look for the top-level js file in a bower component you can use the `primary` module. The `primary` module will exclude gruntfiles and `min.js` files. It will also check if `package.json` specifies a `main` js file.
+
+```js
+var primary = require('bower-requirejs/lib/primary');
+
+var name = 'backbone';
+var dir = ./tmp/bower_components/backbone;
+
+var primaryJS = primary(name, dir);
+// returns backbone.js
+```
+
 ## Credit
 
 [![Sindre Sorhus](http://gravatar.com/avatar/d36a92237c75c5337c17b60d90686bf9?s=144)](http://sindresorhus.com) | [![Rob Dodson](http://gravatar.com/avatar/95c3a3b33ea51545229c625bef42e343?s=144)](http://robdodson.me)


### PR DESCRIPTION
Addresses #65. I think it might be a good idea to remove the `args` object first from the code because it's unused and makes for an awkward explanation in the documentation.
