### PR TITLE
Added type check for dependency main property

### DIFF
--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -17,7 +17,7 @@ module.exports = function (dependencyGraph, opts) {
   if (overrides) {
     _.forOwn(overrides, function (dep, name) {
       if (dep.main) {
-        var main = dep.main.trim();
+        var main = (typeof dep.main === 'string') ? dep.main.trim() : dep.main;
         var dependency = dependencyGraph.dependencies[name];
         if (dependency && main) {
           dependency.pkgMeta.main = main;

--- a/test/unit/build-config.js
+++ b/test/unit/build-config.js
@@ -16,13 +16,17 @@ describe('buildConfig', function () {
    */
   var generateDependencyGraph = function (opts) {
     var baseUrl = opts.baseUrl || '/';
-
+    var overrides = opts.overrides;
     var dependencyGraph = {
       canonicalDir: '/test/canonical/dir',
       pkgMeta: {
         name: 'testName',
       },
     };
+
+    if (overrides) {
+      dependencyGraph.pkgMeta.overrides = overrides;
+    }
 
     var generatedDependencies = {};
 
@@ -44,11 +48,12 @@ describe('buildConfig', function () {
     var dependencies = opts.dependencies || [];
     var moduleType = opts.moduleType;
 
+
     var dep = {
       canonicalDir: path.join(baseUrl, opts.name),
       pkgMeta: {
         name: opts.name,
-        main: 'main.js',
+        main: opts.main || 'main.js',
       },
       dependencies: {}
     };
@@ -146,4 +151,34 @@ describe('buildConfig', function () {
     actual.should.eql(expected);
   });
 
+  it('should create with array as main and configured overrides', function() {
+    var baseUrl = '/';
+    var dependencyGraph = generateDependencyGraph({
+      baseUrl: baseUrl,
+      dependencies: [
+        {
+          name: 'a',
+          main: ['b.js', 'c.js']
+        }
+      ],
+      overrides: {
+        a: {
+          main: ['b.js', 'c.js', 'd.js']
+        }
+      }
+    });
+
+    var actual = buildConfig(dependencyGraph, {baseUrl: baseUrl});
+    var expected = {
+      paths: {
+        b: 'a/b',
+        c: 'a/c',
+        d: 'a/d'
+      },
+      packages: []
+    };
+
+    actual.should.eql(expected);
+  })
+;
 });


### PR DESCRIPTION
This prevents an exception in case the main property is an array. See Issue [#103](https://github.com/yeoman/bower-requirejs/issues/103) for details