### PR TITLE
Bower is warning against a missing "ignore" entry.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,5 +33,6 @@
   },
   "devDependencies": {
     "json2": "*"
-  }
+  },
+  "ignore" : []
 }


### PR DESCRIPTION
```bower requirejs#~2.1.18   invalid-meta requirejs is missing "ignore" entry in bower.json```

This should fix it.