### PR TITLE
Option to shim dependencies. Fixes #64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 components
+bower_components
 tmp

--- a/bin/bower-requirejs.js
+++ b/bin/bower-requirejs.js
@@ -15,6 +15,7 @@ var opts = nopt({
   'base-url': path,
   baseUrl: path, // alias for --base-url
   transitive: Boolean,
+  shim: Boolean,
   'exclude-dev': Boolean
 }, {
   h: '--help',
@@ -23,6 +24,7 @@ var opts = nopt({
   e: '--exclude',
   b: '--base-url',
   t: '--transitive',
+  s: '--shim',
   d: '--exclude-dev'
 });
 
@@ -45,6 +47,7 @@ function help() {
     '  -e, --exclude           # Name of a dependency to be excluded from the process',
     '  -b, --base-url          # Path which all dependencies will be relative to',
     '  -t, --transitive        # Process transitive dependencies',
+    '  -s, --shim              # Shim dependencies',
     '  -d, --exclude-dev       # Exclude devDependencies',
     ''
   ];

--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "node-module-type-stub": "*"
   },
   "resolutions": {
+    "underscore": "~1.5.1",
     "jquery": "~1.10.0"
   },
   "overrides": {

--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -70,9 +70,12 @@ module.exports = function (dependencyGraph, opts) {
       if (configElement.paths) {
         assign(config.paths, configElement.paths);
         if (opts.shim) {
-          var deps = Object.keys(dep.dependencies);
+          var deps = _.difference(Object.keys(dep.dependencies), exclude);
+          if (!opts.transitive) {
+            deps = _.intersection(Object.keys(dependencies), deps);
+          }
           if (deps.length) {
-            config.shim[name] = { deps: _.difference(deps, exclude) };
+            config.shim[name] = { deps: deps };
           }
         }
       }

--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -55,6 +55,7 @@ module.exports = function (dependencyGraph, opts) {
   }
 
   var config = {
+    shim: {},
     paths: {},
     packages: []
   };
@@ -68,6 +69,12 @@ module.exports = function (dependencyGraph, opts) {
     if (configElement) {
       if (configElement.paths) {
         assign(config.paths, configElement.paths);
+        if (opts.shim) {
+          var deps = Object.keys(dep.dependencies);
+          if (deps.length) {
+            config.shim[name] = { deps: _.difference(deps, exclude) };
+          }
+        }
       }
       if (configElement.package) {
         config.packages.push(configElement.package);

--- a/lib/index.js
+++ b/lib/index.js
@@ -108,6 +108,19 @@ module.exports = function (opts, done) {
           config.packages = config.packages.concat(generatedPackages);
         }
 
+        if (generatedConfig.shim) {
+          if (config.shim) {
+            _.forOwn(generatedConfig.shim, function (value, key) {
+              if (config.shim[key]) {
+                config.shim[key].deps = _.union(value.deps, config.shim[key].deps);
+              } else {
+                config.shim[key] = value;
+              }
+            });
+          } else {
+            config.shim = generatedConfig.shim;
+          }
+        }
 
         return config;
       });

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ $ npm install --save bower-requirejs
 -e, --exclude           # Name of a dependency to be excluded from the process'
 -b, --base-url          # Path which all dependencies will be relative to'
 -t, --transitive        # Process transitive dependencies'
+-s, --shim              # Shim dependencies'
 -d, --exclude-dev       # Exclude devDependencies'
 ```
 

--- a/test/acceptance/fixtures/shim-config-expected.js
+++ b/test/acceptance/fixtures/shim-config-expected.js
@@ -6,8 +6,6 @@ var require = {
     'backbone.marionette': {
       deps: [
         'backbone',
-        'backbone.babysitter',
-        'backbone.wreqr',
         'jquery'
       ]
     },

--- a/test/acceptance/fixtures/shim-config-expected.js
+++ b/test/acceptance/fixtures/shim-config-expected.js
@@ -1,0 +1,41 @@
+var require = {
+  shim: {
+    'backbone.babysitter': {
+      deps: ['backbone', '../vendor/backbone.wreqr/reports/coverage/prettify.css']
+    },
+    'backbone.marionette': {
+      deps: [
+        'backbone',
+        'backbone.babysitter',
+        'backbone.wreqr',
+        'jquery'
+      ]
+    },
+    'typeahead.js': {
+      exports: 'jQuery',
+      deps: ['jquery']
+    },
+  },
+  packages: [
+    {
+      name: 'node-module-type-stub',
+      main: 'myMain.js'
+    }
+  ],
+  paths: {
+    anima: '../bower_components/anima/anima.min',
+    'backbone-amd': '../bower_components/backbone-amd/backbone',
+    backbone: '../bower_components/backbone/backbone',
+    'jquery-ui-touch-punch-amd': '../bower_components/jquery-ui-touch-punch-amd/jquery.ui.touch-punch',
+    jquery: '../bower_components/jquery/jquery.min',
+    json2: '../bower_components/json2/json2',
+    requirejs: '../bower_components/requirejs/require',
+    respond: '../bower_components/respond/respond.src',
+    konamicode: '../bower_components/konamicode.js/build/konamicode.min',
+    typeahead: '../bower_components/typeahead.js/dist/typeahead',
+    handlebars: '../bower_components/handlebars/handlebars',
+    mout: '../bower_components/mout/src',
+    'handlebars.runtime': '../bower_components/handlebars/handlebars.runtime',
+    'backbone.marionette': '../bower_components/backbone.marionette/lib/core/amd/backbone.marionette'
+  }
+};

--- a/test/acceptance/fixtures/shim-config.js
+++ b/test/acceptance/fixtures/shim-config.js
@@ -1,0 +1,10 @@
+var require = {
+  shim: {
+    'typeahead.js': {
+      exports: 'jQuery'
+    },
+    'backbone.babysitter': {
+      deps: ['backbone', '../vendor/backbone.wreqr/reports/coverage/prettify.css']
+    }
+  }
+};

--- a/test/acceptance/fixtures/transitive-shim-config-expected.js
+++ b/test/acceptance/fixtures/transitive-shim-config-expected.js
@@ -1,0 +1,45 @@
+var require = {
+  shim: {
+    'backbone.babysitter': {
+      deps: ['backbone', 'underscore', '../vendor/backbone.wreqr/reports/coverage/prettify.css']
+    },
+    'backbone.marionette': {
+      deps: [
+        'backbone',
+        'backbone.babysitter',
+        'backbone.wreqr',
+        'jquery',
+        'underscore'
+      ]
+    },
+    'typeahead.js': {
+      exports: 'jQuery',
+      deps: ['jquery']
+    },
+  },
+  packages: [
+    {
+      name: 'node-module-type-stub',
+      main: 'myMain.js'
+    }
+  ],
+  paths: {
+    typeahead: '../bower_components/typeahead.js/dist/typeahead',
+    respond: '../bower_components/respond/respond.src',
+    requirejs: '../bower_components/requirejs/require',
+    mout: '../bower_components/mout/src',
+    konamicode: '../bower_components/konamicode.js/build/konamicode.min',
+    json2: '../bower_components/json2/json2',
+    'jquery-ui-touch-punch-amd': '../bower_components/jquery-ui-touch-punch-amd/jquery.ui.touch-punch',
+    handlebars: '../bower_components/handlebars/handlebars',
+    'handlebars.runtime': '../bower_components/handlebars/handlebars.runtime',
+    underscore: '../bower_components/underscore/underscore',
+    jquery: '../bower_components/jquery/jquery.min',
+    'backbone.wreqr': '../bower_components/backbone.wreqr/lib/amd/backbone.wreqr',
+    'backbone.babysitter': '../bower_components/backbone.babysitter/lib/backbone.babysitter',
+    'backbone.marionette': '../bower_components/backbone.marionette/lib/core/amd/backbone.marionette',
+    'backbone-amd': '../bower_components/backbone-amd/backbone',
+    backbone: '../bower_components/backbone/backbone',
+    anima: '../bower_components/anima/anima.min'
+  }
+};

--- a/test/acceptance/index.js
+++ b/test/acceptance/index.js
@@ -79,12 +79,34 @@ describe('index', function () {
     });
   });
 
+  describe('shims', function() {
+    it('should return the expected result', function (done) {
+      var opts = { shim: true, config: 'tmp/shim-config.js', exclude: ['underscore'] };
+      require('../../lib')(opts, function () {
+        var actual = jsonify(fs.readFileSync('tmp/shim-config.js', 'utf8'));
+        var expected = jsonify(fs.readFileSync('test/acceptance/fixtures/shim-config-expected.js', 'utf8'));
+        actual.should.eql(expected);
+        done();
+      });
+    });
+  });
+
   describe('with transitive dependencies', function () {
     it('should return the expected result', function (done) {
       var opts = { transitive: true, config: 'tmp/transitive-config.js' };
       require('../../lib')(opts, function () {
         var actual = jsonify(fs.readFileSync('tmp/transitive-config.js', 'utf8'));
         var expected = jsonify(fs.readFileSync('test/acceptance/fixtures/transitive-config-expected.js', 'utf8'));
+        actual.should.eql(expected);
+        done();
+      });
+    });
+
+    it('should shim transitive dependencies', function (done) {
+      var opts = { transitive: true, shim: true, config: 'tmp/shim-config.js' };
+      require('../../lib')(opts, function () {
+        var actual = jsonify(fs.readFileSync('tmp/shim-config.js', 'utf8'));
+        var expected = jsonify(fs.readFileSync('test/acceptance/fixtures/transitive-shim-config-expected.js', 'utf8'));
         actual.should.eql(expected);
         done();
       });

--- a/test/unit/build-config.js
+++ b/test/unit/build-config.js
@@ -142,11 +142,7 @@ describe('buildConfig', function () {
         b: 'b/main'
       },
       packages: [],
-      shim: {
-        b: {
-          deps: ['child-of-b']
-        }
-      }
+      shim: {}
     };
 
     actual.should.eql(expected);

--- a/test/unit/build-config.js
+++ b/test/unit/build-config.js
@@ -89,7 +89,8 @@ describe('buildConfig', function () {
         a: 'a/main',
         b: 'b/main'
       },
-      packages: []
+      packages: [],
+      shim: {}
     };
 
     actual.should.eql(expected);
@@ -115,11 +116,77 @@ describe('buildConfig', function () {
         b: 'b/main',
         'child-of-b': 'child-of-b/main'
       },
-      packages: []
+      packages: [],
+      shim: {}
     };
     actual.should.eql(expected);
   });
 
+  it('should create config w/ only top-level dependencies and shims', function () {
+    var baseUrl = '/';
+    var dependencyGraph = generateDependencyGraph({
+      baseUrl: baseUrl,
+      dependencies: [
+        {name: 'a'},
+        {name: 'b', dependencies: [
+          {name: 'child-of-b'}
+        ]}
+      ]
+    });
+
+    var actual = buildConfig(dependencyGraph, {baseUrl: baseUrl, shim: true});
+
+    var expected = {
+      paths: {
+        a: 'a/main',
+        b: 'b/main'
+      },
+      packages: [],
+      shim: {
+        b: {
+          deps: ['child-of-b']
+        }
+      }
+    };
+
+    actual.should.eql(expected);
+  });
+
+  it('should create config with transitive dependencies and shims', function () {
+    var baseUrl = '/';
+    var dependencyGraph = generateDependencyGraph({
+      baseUrl: baseUrl,
+      dependencies: [
+        {name: 'a'},
+        {name: 'b', dependencies: [
+          {name: 'child-of-b', dependencies: [
+            {name: 'grandchild-of-b'}
+          ]}
+        ]}
+      ]
+    });
+
+    var actual = buildConfig(dependencyGraph, {baseUrl: baseUrl, transitive: true, shim: true});
+
+    var expected = {
+      paths: {
+        a: 'a/main',
+        b: 'b/main',
+        'child-of-b': 'child-of-b/main',
+        'grandchild-of-b': 'grandchild-of-b/main',
+      },
+      packages: [],
+      shim: {
+        b: {
+          deps: ['child-of-b']
+        },
+        'child-of-b': {
+          deps: ['grandchild-of-b']
+        }
+      }
+    };
+    actual.should.eql(expected);
+  });
 
   it('should create without dev-dependencies', function () {
     var baseUrl = '/';
@@ -144,7 +211,8 @@ describe('buildConfig', function () {
         b: 'b/main',
         'child-of-b': 'child-of-b/main'
       },
-      packages: []
+      packages: [],
+      shim: {}
     };
     actual.should.eql(expected);
   });
@@ -173,7 +241,8 @@ describe('buildConfig', function () {
         c: 'a/c',
         d: 'a/d'
       },
-      packages: []
+      packages: [],
+      shim: {}
     };
 
     actual.should.eql(expected);


### PR DESCRIPTION
An option to shim dependencies. Differences from #101:

1. Tests, both unit and functional
2. No additional dependencies
3. No copy and pasted code
4. One option, and it shims everything, without checking if it's an AMD package. I realized that if the bower dependencies and the require.js dependencies differ for a package, it's likely a bug in that package. Also, it seems very few bower packages actually properly declare they support AMD, by manual inspection.